### PR TITLE
Error on library.json

### DIFF
--- a/library.json
+++ b/library.json
@@ -19,9 +19,9 @@
   "url": "https://github.com/witnessmenow/ESP32-Cheap-Yellow-Display",
   "architectures": ["esp32"],
   "frameworks": "Arduino",
-  "dependencies": {
+  "dependencies": [
     "bodmer/TFT_eSPI@^2.5.31"
-  },
+  ],
   "examples": [
     {
       "name": "1.Hello World",


### PR DESCRIPTION
Had issues with adding this to PlatformIO to learn how to use the cheap yellow display. Is "dependencies" supposed to be a list of strings not a key-value pair?